### PR TITLE
Bug Fix: Correct Division Operation and Test Parameter in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ def divide(a: int, b: int) -> Optional[float]:
         Optional[float]: The result of the division if successful, None otherwise.
     """
     try:
-        return a / bfe
+        return a / b
     except ZeroDivisionError:
         logging.error('Error: Division by zero is not allowed.')
         return None
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     
     # Test division by zero
-    result = divide("22", 0)
+    result = divide(22, 0)
     if result is not None:
         print(result)
     else:


### PR DESCRIPTION
## Changes Made
- Fixed typo in division operation (`a / bfe` → `a / b`)
- Corrected test case parameter from string "22" to integer 22 to match function type hints

## Reason for Changes
- The `bfe` typo caused a syntax error
- The string parameter would trigger a `TypeError` during execution due to type mismatch

## Details
- Code structure and error handling were already well-implemented
- No further changes were needed for readability or architecture